### PR TITLE
Bump buildroot to 2025.08

### DIFF
--- a/bootgen-alt/Config.in.host
+++ b/bootgen-alt/Config.in.host
@@ -1,0 +1,10 @@
+config BR2_PACKAGE_HOST_BOOTGEN
+	bool "host bootgen"
+	help
+	  bootgen is a tool to generate a boot.bin firmware
+	  for Xilinx versal, zynqmp and zynq product families.
+
+	  Additional secure boot features are supported beyond
+	  what is included with u-boot mkimage.
+
+	  https://github.com/Xilinx/bootgen

--- a/bootgen-alt/bootgen.hash
+++ b/bootgen-alt/bootgen.hash
@@ -1,0 +1,3 @@
+# Locally calculated
+sha256  2c8345a3bea4fcec6ceb6c8f8e727a610aaca3ec71cdf7f892d7f89f88438650  bootgen-xilinx_v2024.2.tar.gz
+sha256  4da5f5eff0592e5d275f1871faf9e9a4fc0f6346027bfb777fa59d0aa6a59aa3  LICENSE

--- a/bootgen-alt/bootgen.mk
+++ b/bootgen-alt/bootgen.mk
@@ -1,0 +1,25 @@
+################################################################################
+#
+# bootgen
+#
+################################################################################
+
+BOOTGEN_VERSION = xilinx_v2024.2
+BOOTGEN_SITE = $(call github,Xilinx,bootgen,$(BOOTGEN_VERSION))
+HOST_BOOTGEN_DEPENDENCIES = host-openssl host-pkgconf
+BOOTGEN_LICENSE = Apache-2.0
+BOOTGEN_LICENSE_FILES = LICENSE
+
+define HOST_BOOTGEN_BUILD_CMDS
+	$(MAKE) $(HOST_CONFIGURE_OPTS) \
+		LIBS="`$(HOST_MAKE_ENV) $(PKG_CONFIG_HOST_BINARY) --libs libssl libcrypto`" \
+		INCLUDE_USER="`$(HOST_MAKE_ENV) $(PKG_CONFIG_HOST_BINARY) --cflags libssl libcrypto`" \
+		CXXFLAGS="$(HOST_CXXFLAGS) -std=c++0x" \
+		-C $(@D)
+endef
+
+define HOST_BOOTGEN_INSTALL_CMDS
+	$(INSTALL) -m 0755 -D $(@D)/bootgen $(HOST_DIR)/bin/bootgen
+endef
+
+$(eval $(host-generic-package))

--- a/getbuildroot.sh
+++ b/getbuildroot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-wget -O- https://buildroot.org/downloads/buildroot-2025.05.tar.gz | tar -xz --one-top-level=buildroot --strip-components=1
+wget -O- https://buildroot.org/downloads/buildroot-2025.08.tar.gz | tar -xz --one-top-level=buildroot --strip-components=1
 
 patch -p0 << 'EOF'
 --- buildroot/support/docker/Dockerfile	2025-05-26 20:56:37.937741302 +0300
@@ -97,3 +97,9 @@ patch -p0 << 'EOF'
      docker_opts+=( --env BR2_DL_DIR )
 
 EOF
+
+# Substitute bootgen package with older version. Bootgen 2025.01 produces a broken binary.
+# This replaces bootgen 2025.01 with bootgen 2024.2 from Buildroot 2025.05.
+echo "Substituting bootgen package with older version"
+rm -r buildroot/package/bootgen
+cp -a bootgen-alt buildroot/package/bootgen

--- a/package/rust-wasm/rust-wasm.mk
+++ b/package/rust-wasm/rust-wasm.mk
@@ -6,7 +6,7 @@
 
 # When updating this version, check whether support/download/cargo-post-process
 # still generates the same archives.
-RUST_WASM_VERSION = 1.86.0
+RUST_WASM_VERSION = 1.88.0
 RUST_WASM_SITE = https://static.rust-lang.org/dist
 RUST_WASM_LICENSE = Apache-2.0 or MIT
 RUST_WASM_LICENSE_FILES = LICENSE-APACHE LICENSE-MIT


### PR DESCRIPTION
Bump buildroot to 2025.08; Bump rust-wasm to 1.88; Replace bootgen 2025.1 with 2024.2 as the buildroot package produces a broken binary